### PR TITLE
Add Javadoc-style documentation to Python files

### DIFF
--- a/Project_refactored/internal/asset_loader.py
+++ b/Project_refactored/internal/asset_loader.py
@@ -1,8 +1,21 @@
 import pygame
 from internal.config import IMAGE_PATHS, SOUND_PATHS
 
+"""
+This module provides functions for loading game assets, including images and sounds.
+It uses the pygame library for asset loading and handling.
+"""
+
 def load_images():
-    """Загружает все игровые изображения."""
+    """
+    Loads all game images.
+
+    This function iterates over the IMAGE_PATHS dictionary, loads each image
+    using pygame.image.load(), and stores it in a dictionary. If an image
+    cannot be loaded, a placeholder surface is created.
+
+    @return: A dictionary where keys are image names and values are pygame.Surface objects.
+    """
     images = {}
     for name, path in IMAGE_PATHS.items():
         try:
@@ -14,7 +27,15 @@ def load_images():
     return images
 
 def load_sounds():
-    """Загружает все игровые звуки."""
+    """
+    Loads all game sounds.
+
+    This function iterates over the SOUND_PATHS dictionary, loads each sound
+    using pygame.mixer.Sound(), and stores it in a dictionary. Sounds named
+    'music' are skipped as they are handled separately.
+
+    @return: A dictionary where keys are sound names and values are pygame.mixer.Sound objects.
+    """
     sounds = {}
     for name, path in SOUND_PATHS.items():
         if name == 'music':
@@ -26,7 +47,12 @@ def load_sounds():
     return sounds
 
 def load_and_play_music():
-    """Загружает и запускает фоновую музыку."""
+    """
+    Loads and plays background music.
+
+    This function loads the music specified by SOUND_PATHS['music'] and
+    plays it indefinitely using pygame.mixer.music.
+    """
     try:
         pygame.mixer.music.load(SOUND_PATHS['music'])
         pygame.mixer.music.play(-1)

--- a/Project_refactored/internal/config.py
+++ b/Project_refactored/internal/config.py
@@ -2,50 +2,60 @@ import pygame
 import sys
 import os
 
-# Экран
-SCREEN_WIDTH = 400
-SCREEN_HEIGHT = 600
-FPS = 60
-GAME_TITLE = "Война с инопланетянами"
+"""
+This module defines configuration variables for the game.
+It includes settings for screen dimensions, frame rate, game title, colors,
+asset paths, font settings, and gameplay parameters.
+"""
 
-# Цвета
-WHITE = (255, 255, 255)
-BLACK = (0, 0, 0)
-RED = (255, 0, 0)
-GREEN = (0, 255, 0)
-BLUE = (0, 0, 255)
-GRAY = (128, 128, 128)
+# Screen configuration
+SCREEN_WIDTH = 400  # Width of the game screen in pixels
+SCREEN_HEIGHT = 600  # Height of the game screen in pixels
+FPS = 60  # Frames per second for the game loop
+GAME_TITLE = "Война с инопланетянами"  # Title of the game window
 
-ASSET_BASE_PATH = 'assets/'
+# Color definitions (RGB tuples)
+WHITE = (255, 255, 255)  # White color
+BLACK = (0, 0, 0)  # Black color
+RED = (255, 0, 0)  # Red color
+GREEN = (0, 255, 0)  # Green color
+BLUE = (0, 0, 255)  # Blue color
+GRAY = (128, 128, 128)  # Gray color
 
-# Проверяем, запущен ли скрипт из PyInstaller
+# Asset base path configuration
+ASSET_BASE_PATH = 'assets/'  # Default base path for assets
+
+# Check if the script is running from PyInstaller
 if getattr(sys, 'frozen', False):
-    # Если да, используем путь к временной директории, созданной PyInstaller
+    # If yes, use the path to the temporary directory created by PyInstaller
     ASSET_BASE_PATH = os.path.join(sys._MEIPASS, 'assets') + os.sep
 else:
-    # Иначе, используем обычный относительный путь (для разработки)
+    # Otherwise, use the regular relative path (for development)
     ASSET_BASE_PATH = 'assets' + os.sep
 
-
+# Image asset paths
 IMAGE_PATHS = {
-    'background': ASSET_BASE_PATH + 'Background.png',
-    'player': ASSET_BASE_PATH + 'player.png',
-    'mob': ASSET_BASE_PATH + 'mob.png',
-    'bullet': ASSET_BASE_PATH + 'Bullet.png'
+    'background': ASSET_BASE_PATH + 'Background.png',  # Path to the background image
+    'player': ASSET_BASE_PATH + 'player.png',  # Path to the player sprite
+    'mob': ASSET_BASE_PATH + 'mob.png',  # Path to the mob sprite
+    'bullet': ASSET_BASE_PATH + 'Bullet.png'  # Path to the bullet sprite
 }
 
+# Sound asset paths
 SOUND_PATHS = {
-    'music': ASSET_BASE_PATH + 'phon.mp3',
-    'shoot': ASSET_BASE_PATH + 'laster.mp3',
-    'explosion': ASSET_BASE_PATH + 'explosion.wav'
+    'music': ASSET_BASE_PATH + 'phon.mp3',  # Path to the background music file
+    'shoot': ASSET_BASE_PATH + 'laster.mp3',  # Path to the shooting sound effect
+    'explosion': ASSET_BASE_PATH + 'explosion.wav'  # Path to the explosion sound effect
 }
 
-FONT_NAME_DEFAULT = None
-FONT_SIZE_LARGE = 55
-FONT_SIZE_MEDIUM = 36
+# Font settings
+FONT_NAME_DEFAULT = None  # Default font name (None for system default)
+FONT_SIZE_LARGE = 55  # Large font size
+FONT_SIZE_MEDIUM = 36  # Medium font size
 
-PLAYER_LIVES_START = 3
-MOB_SPAWN_TIME_MS = 500
-BULLET_SPEED = -10
-MOB_SPEED_MIN = 2
-MOB_SPEED_MAX = 4
+# Gameplay settings
+PLAYER_LIVES_START = 3  # Initial number of lives for the player
+MOB_SPAWN_TIME_MS = 500  # Time interval in milliseconds for mob spawning
+BULLET_SPEED = -10  # Speed of bullets (negative for upward movement)
+MOB_SPEED_MIN = 2  # Minimum speed for mobs
+MOB_SPEED_MAX = 4  # Maximum speed for mobs

--- a/Project_refactored/internal/game_logic.py
+++ b/Project_refactored/internal/game_logic.py
@@ -1,11 +1,30 @@
 import pygame
 from internal.sprites import Player, Mob, Bullet
-from internal.config import (SCREEN_WIDTH, SCREEN_HEIGHT, BLACK, PLAYER_LIVES_START, 
+from internal.config import (SCREEN_WIDTH, SCREEN_HEIGHT, BLACK, PLAYER_LIVES_START,
                     MOB_SPAWN_TIME_MS, FONT_NAME_DEFAULT, FONT_SIZE_MEDIUM)
 from internal.ui import draw_text
 
+"""
+This module contains the main game loop and related game logic.
+It handles event processing, sprite updates, collision detection,
+and rendering the game state to the screen.
+"""
+
 def game_loop(screen, clock, images, sounds):
-    """Основной игровой цикл."""
+    """
+    Runs the main game loop.
+
+    This function initializes the game state, including the player, mobs, and bullets.
+    It handles user input, updates game objects, checks for collisions,
+    and draws the game on the screen. The loop continues until the player quits
+    or loses all lives.
+
+    @param screen: The pygame.Surface object representing the game screen.
+    @param clock: The pygame.time.Clock object for managing game speed.
+    @param images: A dictionary of loaded game images.
+    @param sounds: A dictionary of loaded game sounds.
+    @return: The player's score if the game ends normally, or -1 if the player quits.
+    """
     
     pygame.mouse.set_visible(False)
     pygame.event.set_grab(True)

--- a/Project_refactored/internal/sprites.py
+++ b/Project_refactored/internal/sprites.py
@@ -2,8 +2,28 @@ import pygame
 import random
 from internal.config import SCREEN_WIDTH, SCREEN_HEIGHT, BULLET_SPEED, MOB_SPEED_MIN, MOB_SPEED_MAX
 
+"""
+This module defines sprite classes for game objects.
+It includes classes for Mobs (enemies), the Player, and Bullets.
+These classes inherit from pygame.sprite.Sprite and handle their
+own appearance, movement, and behavior.
+"""
+
 class Mob(pygame.sprite.Sprite):
+    """
+    Represents an enemy mob in the game.
+
+    Attributes:
+        image (pygame.Surface): The image of the mob.
+        rect (pygame.Rect): The rectangular area of the mob.
+        speed (int): The vertical speed of the mob.
+    """
     def __init__(self, mob_image):
+        """
+        Initializes a new Mob instance.
+
+        @param mob_image: The pygame.Surface to use as the mob's image.
+        """
         super().__init__()
         self.image = mob_image
         self.rect = self.image.get_rect()
@@ -12,12 +32,31 @@ class Mob(pygame.sprite.Sprite):
         self.speed = random.randint(MOB_SPEED_MIN, MOB_SPEED_MAX)
 
     def update(self):
+        """
+        Updates the mob's position.
+        The mob moves downwards, and if it goes off the bottom of the screen,
+        it is removed from all sprite groups.
+        """
         self.rect.y += self.speed
         if self.rect.y > SCREEN_HEIGHT:
             self.kill()
 
 class Player(pygame.sprite.Sprite):
+    """
+    Represents the player character in the game.
+
+    Attributes:
+        image (pygame.Surface): The image of the player.
+        rect (pygame.Rect): The rectangular area of the player.
+        lives (int): The number of lives the player has.
+    """
     def __init__(self, player_image, initial_lives):
+        """
+        Initializes a new Player instance.
+
+        @param player_image: The pygame.Surface to use as the player's image.
+        @param initial_lives: The starting number of lives for the player.
+        """
         super().__init__()
         self.image = player_image
         self.rect = self.image.get_rect()
@@ -26,6 +65,11 @@ class Player(pygame.sprite.Sprite):
         self.lives = initial_lives
 
     def update(self):
+        """
+        Updates the player's position based on mouse movement.
+        The player's horizontal position is controlled by the mouse,
+        and it is kept within the screen boundaries.
+        """
         mouse_x, mouse_y = pygame.mouse.get_pos()
         self.rect.centerx = mouse_x
 
@@ -35,7 +79,22 @@ class Player(pygame.sprite.Sprite):
             self.rect.right = SCREEN_WIDTH
         
 class Bullet(pygame.sprite.Sprite):
+    """
+    Represents a bullet fired by the player.
+
+    Attributes:
+        image (pygame.Surface): The image of the bullet.
+        rect (pygame.Rect): The rectangular area of the bullet.
+        speed (int): The vertical speed of the bullet.
+    """
     def __init__(self, bullet_image, x, y):
+        """
+        Initializes a new Bullet instance.
+
+        @param bullet_image: The pygame.Surface to use as the bullet's image.
+        @param x: The initial x-coordinate of the bullet's center.
+        @param y: The initial y-coordinate of the bullet's bottom.
+        """
         super().__init__()
         self.image = bullet_image
         self.rect = self.image.get_rect()
@@ -44,6 +103,11 @@ class Bullet(pygame.sprite.Sprite):
         self.speed = BULLET_SPEED
 
     def update(self):
+        """
+        Updates the bullet's position.
+        The bullet moves upwards, and if it goes off the top of the screen,
+        it is removed from all sprite groups.
+        """
         self.rect.y += self.speed
         if self.rect.bottom < 0:
             self.kill()

--- a/Project_refactored/internal/ui.py
+++ b/Project_refactored/internal/ui.py
@@ -1,8 +1,29 @@
 import pygame
 from internal.config import SCREEN_WIDTH, SCREEN_HEIGHT, BLACK, GRAY, FONT_NAME_DEFAULT, FONT_SIZE_LARGE
 
+"""
+This module provides functions for creating and displaying User Interface (UI) elements.
+It includes functions for drawing text, and showing start and end game screens.
+"""
+
 def draw_text(surface, text, size, x, y, color, font_name=FONT_NAME_DEFAULT, center_aligned=True):
-    """Утилита для отрисовки текста."""
+    """
+    Draws text on a given surface.
+
+    This utility function renders text using a specified font and color,
+    and blits it onto the provided surface at the given coordinates.
+
+    @param surface: The pygame.Surface to draw the text on.
+    @param text: The string of text to draw.
+    @param size: The font size.
+    @param x: The x-coordinate for the text position.
+    @param y: The y-coordinate for the text position.
+    @param color: The color of the text (RGB tuple).
+    @param font_name: The name of the font to use (defaults to FONT_NAME_DEFAULT).
+    @param center_aligned: Boolean indicating if the text should be centered at (x, y).
+                           If False, (x, y) is the top-left corner.
+    @return: The pygame.Rect object representing the bounds of the rendered text.
+    """
     font = pygame.font.SysFont(font_name, size)
     text_surface = font.render(text, True, color)
     text_rect = text_surface.get_rect()
@@ -14,6 +35,16 @@ def draw_text(surface, text, size, x, y, color, font_name=FONT_NAME_DEFAULT, cen
     return text_rect
 
 def show_start_screen(screen, background_image):
+    """
+    Displays the start screen of the game.
+
+    This function shows a welcome message and a "Play" button. It waits for
+    player input (either closing the window or clicking the button).
+
+    @param screen: The pygame.Surface object representing the game screen.
+    @param background_image: The pygame.Surface to use as the background.
+    @return: True if the player clicks "Play", False if the player quits.
+    """
     screen.blit(background_image, (0, 0))
     draw_text(screen, 'Добро пожаловать', FONT_SIZE_LARGE, SCREEN_WIDTH // 2, SCREEN_HEIGHT // 2 - 50, BLACK)
     
@@ -35,6 +66,17 @@ def show_start_screen(screen, background_image):
     return False
 
 def show_end_screen(screen, background_image, score):
+    """
+    Displays the end screen of the game.
+
+    This function shows a "Game Over" message, the player's final score,
+    and a "Play Again" button. It waits for player input.
+
+    @param screen: The pygame.Surface object representing the game screen.
+    @param background_image: The pygame.Surface to use as the background.
+    @param score: The player's final score to display.
+    @return: True if the player clicks "Play Again", False if the player quits.
+    """
     screen.blit(background_image, (0, 0))
     draw_text(screen, 'Вы проиграли!', FONT_SIZE_LARGE, SCREEN_WIDTH // 2, SCREEN_HEIGHT // 2 - 70, BLACK)
     draw_text(screen, f'Счёт: {score}', FONT_SIZE_LARGE, SCREEN_WIDTH // 2, SCREEN_HEIGHT // 2 - 20, BLACK)

--- a/Project_refactored/main.py
+++ b/Project_refactored/main.py
@@ -4,7 +4,21 @@ import internal.asset_loader as asset_loader
 import internal.ui as ui
 import internal.game_logic as game_logic
 
+"""
+This module is the main entry point for the game.
+It initializes pygame, loads assets, and manages the overall game flow,
+including displaying start/end screens and running the main game loop.
+"""
+
 def main():
+    """
+    Main function to run the game.
+
+    Initializes pygame and its mixer, sets up the game window,
+    loads assets (images and sounds), and then enters the main application loop.
+    This loop handles showing the start screen, running the game logic,
+    and showing the end screen, allowing the player to restart or quit.
+    """
     pygame.init()
     pygame.mixer.init()
 


### PR DESCRIPTION
This commit adds Javadoc-style docstrings to all Python files in the Project_refactored directory.

- Added module-level docstrings to all Python files.
- Added Javadoc-style docstrings to all functions, classes, and methods, explaining their purpose, arguments, attributes, and return values as appropriate.
- Added comments to configuration variables in config.py.